### PR TITLE
BUGFIX: fix globalHealth not returning to OK after a FAILED state

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,10 +1,40 @@
 module aahframe.work/ec/health
 
+go 1.18
+
 require (
-	aahframe.work v0.12.3
-	github.com/stretchr/testify v1.2.2
-	golang.org/x/sync v0.0.0-20190227155943-e225da77a7e6 // indirect
-	golang.org/x/sys v0.0.0-20190329044733-9eb1bfa1ce65 // indirect
-	google.golang.org/appengine v1.5.0 // indirect
+	aahframe.work v0.12.5
+	github.com/stretchr/testify v1.8.1
+)
+
+require (
+	cloud.google.com/go v0.106.0 // indirect
+	cloud.google.com/go/compute v1.12.1 // indirect
+	cloud.google.com/go/compute/metadata v0.2.1 // indirect
+	github.com/cpuguy83/go-md2man/v2 v2.0.0-20190314233015-f79a8a8ca69d // indirect
+	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/go-aah/forge v0.8.0 // indirect
+	github.com/go-playground/locales v0.14.0 // indirect
+	github.com/go-playground/universal-translator v0.18.0 // indirect
+	github.com/gobwas/httphead v0.1.0 // indirect
+	github.com/gobwas/pool v0.2.1 // indirect
+	github.com/gobwas/ws v1.1.0 // indirect
+	github.com/golang/protobuf v1.5.2 // indirect
+	github.com/leodido/go-urn v1.2.1 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
+	github.com/russross/blackfriday/v2 v2.0.1 // indirect
+	github.com/shurcooL/sanitized_anchor_name v1.0.0 // indirect
+	github.com/stretchr/objx v0.5.0 // indirect
+	github.com/urfave/cli v1.22.10 // indirect
+	golang.org/x/crypto v0.2.0 // indirect
+	golang.org/x/net v0.2.0 // indirect
+	golang.org/x/oauth2 v0.2.0 // indirect
+	golang.org/x/sync v0.1.0 // indirect
+	golang.org/x/sys v0.2.0 // indirect
+	golang.org/x/text v0.4.0 // indirect
+	google.golang.org/appengine v1.6.7 // indirect
+	google.golang.org/protobuf v1.28.1 // indirect
 	gopkg.in/go-playground/assert.v1 v1.2.1 // indirect
+	gopkg.in/go-playground/validator.v9 v9.31.0 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/health.go
+++ b/health.go
@@ -95,7 +95,7 @@ func (c *Collector) runChecks() {
 	c.mu.RLock()
 	wg.Add(len(c.reporters))
 
-	c.globalHealth = true
+	globalHealthy := true
 	for _, cfg := range c.reporters {
 		go func(rc *Config) {
 			defer wg.Done()
@@ -103,7 +103,7 @@ func (c *Collector) runChecks() {
 			if err := rc.Reporter.Check(); err != nil {
 				if !rc.SoftFail {
 					c.mu.Lock()
-					c.globalHealth = false
+					globalHealthy = false
 					c.mu.Unlock()
 				}
 				c.mu.Lock()
@@ -115,6 +115,15 @@ func (c *Collector) runChecks() {
 				c.mu.Unlock()
 			}
 		}(cfg)
+	}
+	if globalHealthy {
+		c.mu.Lock()
+		c.globalHealth = true
+		c.mu.Unlock()
+	} else {
+		c.mu.Lock()
+		c.globalHealth = false
+		c.mu.Unlock()
 	}
 	c.mu.RUnlock()
 

--- a/health.go
+++ b/health.go
@@ -95,6 +95,7 @@ func (c *Collector) runChecks() {
 	c.mu.RLock()
 	wg.Add(len(c.reporters))
 
+	c.globalHealth = true
 	for _, cfg := range c.reporters {
 		go func(rc *Config) {
 			defer wg.Done()


### PR DESCRIPTION
We have run into an issue where once a HC has `FAILED`, it will never go back to `OK`.

This is because on each `healthcheck.Check()` we scan for failed checks, if any check fails, we set the global health to false and return a 503. On subsequent checks, if all results are OK, there is not code to set the global health back to OK.

This PR ensures we start from an OK state on each check, if any checks fail, we set the global state to false. On subsequent requests, we set back to OK prior to doing the checks, so if any checks fail it will be set again to FALSE before replying, and if all checks are OK, the OK state is kept.

@adrianlop @jeevatkm please let me know your thoughts on this.

As this is a bugfix, we should tag a new version.