### PR TITLE
fix globalhealth update with a local bool to avoid false globalHealth reports

### DIFF
--- a/health.go
+++ b/health.go
@@ -95,7 +95,7 @@ func (c *Collector) runChecks() {
 	c.mu.RLock()
 	wg.Add(len(c.reporters))
 
-	c.globalHealth = true
+	globalHealthy := true
 	for _, cfg := range c.reporters {
 		go func(rc *Config) {
 			defer wg.Done()
@@ -103,7 +103,7 @@ func (c *Collector) runChecks() {
 			if err := rc.Reporter.Check(); err != nil {
 				if !rc.SoftFail {
 					c.mu.Lock()
-					c.globalHealth = false
+					globalHealthy = false
 					c.mu.Unlock()
 				}
 				c.mu.Lock()
@@ -115,6 +115,15 @@ func (c *Collector) runChecks() {
 				c.mu.Unlock()
 			}
 		}(cfg)
+	}
+	if globalHealthy {
+		c.mu.Lock()
+		c.globalHealth = true
+		c.mu.Unlock()
+	} else {
+		c.mu.Lock()
+		c.globalHealth = false
+		c.mu.Unlock()
 	}
 	c.mu.RUnlock()
 


### PR DESCRIPTION
@joelsdc this might be safer, it'll use a local bool var instead of changing the globalHealth to true, which can report a false `healthy` state in some cases while you're still performing the checks