### PR TITLE
Fix globalhealth blocked waiting to acquire write lock

### DIFF
--- a/health.go
+++ b/health.go
@@ -92,7 +92,6 @@ func (c *Collector) AddReporter(config *Config) error {
 func (c *Collector) runChecks() {
 	//create syncgroup and check all dependencies
 	var wg sync.WaitGroup
-	c.mu.RLock()
 	wg.Add(len(c.reporters))
 
 	globalHealthy := true
@@ -116,6 +115,8 @@ func (c *Collector) runChecks() {
 			}
 		}(cfg)
 	}
+
+	// update global health status
 	if globalHealthy {
 		c.mu.Lock()
 		c.globalHealth = true
@@ -125,7 +126,6 @@ func (c *Collector) runChecks() {
 		c.globalHealth = false
 		c.mu.Unlock()
 	}
-	c.mu.RUnlock()
 
 	// wait for all the deps to finish the checks
 	wg.Wait()

--- a/health.go
+++ b/health.go
@@ -116,6 +116,9 @@ func (c *Collector) runChecks() {
 		}(cfg)
 	}
 
+	// wait for all the deps to finish the checks
+	wg.Wait()
+
 	// update global health status
 	if globalHealthy {
 		c.mu.Lock()
@@ -126,9 +129,6 @@ func (c *Collector) runChecks() {
 		c.globalHealth = false
 		c.mu.Unlock()
 	}
-
-	// wait for all the deps to finish the checks
-	wg.Wait()
 }
 
 // Register method registers the health collector into aah application with


### PR DESCRIPTION
After the latest fix for GlobalHealth status, we are now running into issues where the code will be blocked while waiting to acquire a write lock.

This PR aims to solve that issue.